### PR TITLE
feat: add new sequence function

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pnpm": ">=9.0.0"
   },
   "devDependencies": {
-    "@hypernym/eslint-config": "^3.5.5",
+    "@hypernym/eslint-config": "^3.5.6",
     "@hypernym/prettier-config": "^3.2.2",
     "@hypernym/tsconfig": "^2.5.0",
     "@types/node": "^22.13.1",

--- a/packages/effekt/src/animation/types/targets.ts
+++ b/packages/effekt/src/animation/types/targets.ts
@@ -1,9 +1,3 @@
-export type AnimationTarget = {
-  value: Element
-  index: number
-  total: number
-}
-
 export type AnimationTargets =
   | string
   | Element

--- a/packages/effekt/src/sequence/index.ts
+++ b/packages/effekt/src/sequence/index.ts
@@ -1,0 +1,29 @@
+import { createSequence } from './sequence'
+import type { Sequence, SequenceAnimation, SequenceOptions } from './types'
+
+/**
+ * Creates a new `Sequence` object that plays animations in a specified order.
+ *
+ * The `sequence` function allows you to chain multiple animations with precise control and synchronization of each step in the sequence.
+ *
+ * Ensures that animations are played sequentially, with the ability to define other properties and methods to manage the flow of the animations.
+ *
+ * @example
+ *
+ * ```ts
+ * import { sequence } from 'effekt/sequence'
+ *
+ * const sq = sequence([
+ *   ['.el1', { opacity: [1, 0.5] }],
+ *   ['.el2', { opacity: [0.5, 1] }],
+ * ])
+ *
+ * sq.play() // Plays the sequence
+ * ```
+ */
+export function sequence(
+  animations: SequenceAnimation[],
+  options?: SequenceOptions,
+): Sequence {
+  return createSequence(animations, options)
+}

--- a/packages/effekt/src/sequence/sequence.ts
+++ b/packages/effekt/src/sequence/sequence.ts
@@ -1,0 +1,111 @@
+import { noop } from '@/shared'
+import { nextTick } from '@/utils'
+import { createAnimation } from '@/animation'
+import type {
+  Sequence,
+  SequenceAnimation,
+  SequenceOptions,
+  SequenceEventNames,
+} from './types'
+import type { Animation } from '@/animation/types'
+
+export function createSequence(
+  animations: SequenceAnimation[],
+  options: SequenceOptions = {},
+): Sequence {
+  const { timeline } = options
+
+  const sequence: Animation[] = []
+  let isCompleted: boolean = false
+  let isTimeline: boolean = timeline ? true : false
+
+  let resolve: (value: globalThis.Animation[][]) => void
+  let reject: (value: any) => void
+
+  for (let i = 0, l = animations.length; i < l; i++) {
+    const [targets, settings] = animations[i]
+
+    const animation = createAnimation(targets, {
+      autoplay: false,
+      ...settings,
+      timeline,
+    })
+
+    sequence.push(animation)
+  }
+
+  let isReady: boolean = sequence.length > 0
+
+  const each = (callback: (a: Animation) => void): void => {
+    for (let i = 0, l = sequence.length; i < l; i++) callback(sequence[i])
+  }
+
+  const run = (name: SequenceEventNames): void => each((a) => a[name]())
+
+  const call = (callback?: (sequence: Animation[]) => void): void => {
+    if (isReady) callback?.(sequence)
+  }
+
+  const sequencer: Sequence = {
+    async play(): Promise<void> {
+      call(options.onPlay)
+      try {
+        for (const a of sequence) {
+          a.play()
+          await a.completed
+        }
+      } catch {}
+    },
+    pause(): void {
+      run('pause')
+      call(options.onPause)
+    },
+    stop(): void {
+      run('stop')
+      call(options.onStop)
+    },
+    complete(): void {
+      run('complete')
+    },
+    cancel(): void {
+      run('cancel')
+    },
+    completed: new Promise((res, rej): void => {
+      resolve = res
+      reject = rej
+    }),
+    get timeline(): globalThis.AnimationTimeline | null {
+      return sequence[0]?.timeline || null
+    },
+    set timeline(t) {
+      isTimeline ||= true
+      each((a) => (a.timeline = t))
+    },
+    get isCompleted(): Readonly<boolean> {
+      return isCompleted && !isTimeline
+    },
+  }
+
+  if (isReady) {
+    options.onStart?.(sequence)
+
+    sequencer.completed.catch(noop)
+
+    Promise.all(sequence.map((a) => a.completed))
+      .then((a) => {
+        isCompleted = true
+        nextTick(() => {
+          resolve?.(a)
+          options.onComplete?.(a)
+        })
+      })
+      .catch((err) => {
+        nextTick(() => {
+          reject?.(err)
+          options.onCancel?.(err)
+        })
+      })
+  }
+
+  return sequencer
+}

--- a/packages/effekt/src/sequence/types/events.ts
+++ b/packages/effekt/src/sequence/types/events.ts
@@ -1,0 +1,64 @@
+import type { Animation } from '@/animation/types'
+
+export interface SequenceEvents {
+  /**
+   * Triggered when the sequence start.
+   *
+   * This event occurs at the beginning of the sequence.
+   *
+   * It can be used to initialize sequence-related settings or to trigger other actions.
+   *
+   * @default undefined
+   */
+  onStart?: (animations: Animation[]) => void
+  /**
+   * Triggered when the sequence is played.
+   *
+   * This event occurs when the sequence transition from a paused or stopped state to a playing state.
+   *
+   * It can be used to resume animations, update the UI, or synchronize other animations.
+   *
+   * @default undefined
+   */
+  onPlay?: (animations: Animation[]) => void
+  /**
+   * Triggered when the sequence is paused.
+   *
+   * This event occurs when the sequence are temporarily halted.
+   *
+   * It can be used to save the current state of animations, update the UI, or perform other actions.
+   *
+   * @default undefined
+   */
+  onPause?: (animations: Animation[]) => void
+  /**
+   * Triggered when the sequence is stopped.
+   *
+   * This event occurs when animations are completely stopped before their natural completion.
+   *
+   * It can be used to stop animations, release resources, or perform specific tasks.
+   *
+   * @default undefined
+   */
+  onStop?: (animations: Animation[]) => void
+  /**
+   * Triggered when the sequence ends.
+   *
+   * This event occurs when animations reach their end point naturally.
+   *
+   * It can be used to trigger actions that should only happen once animations are fully complete.
+   *
+   * @default undefined
+   */
+  onComplete?: (animations: globalThis.Animation[][]) => void
+  /**
+   * Triggered when the sequence is canceled due to error.
+   *
+   * This event occurs when animations are interrupted or canceled due to an error or external cause.
+   *
+   * It can be used to handle errors gracefully, log error information, or attempt recovery actions.
+   *
+   * @default undefined
+   */
+  onCancel?: (error: any) => void
+}

--- a/packages/effekt/src/sequence/types/index.ts
+++ b/packages/effekt/src/sequence/types/index.ts
@@ -1,0 +1,2 @@
+export * from './options'
+export * from './sequence'

--- a/packages/effekt/src/sequence/types/options.ts
+++ b/packages/effekt/src/sequence/types/options.ts
@@ -1,0 +1,31 @@
+import type { SequenceEvents } from './events'
+import type { AnimationTargets, AnimationOptions } from '@/animation/types'
+
+export type SequenceAnimation = [
+  AnimationTargets,
+  Omit<AnimationOptions, 'timeline'>,
+]
+
+export interface SequenceOptions extends SequenceEvents {
+  /**
+   * Specifies the animation `timeline` features, inherited by other types:
+   *
+   * - `DocumentTimeline`
+   * - `ScrollTimeline`
+   * - `ViewTimeline`
+   *
+   * @experimental [Browser support](https://developer.mozilla.org/en-US/docs/Web/API/AnimationTimeline) (2025): 74.8%
+   *
+   * @default undefined
+   */
+  timeline?: globalThis.AnimationTimeline | null
+}
+
+export type SequenceEventNames =
+  | 'play'
+  | 'pause'
+  | 'stop'
+  | 'complete'
+  | 'cancel'
+
+export type SequencePromise = Promise<globalThis.Animation[][]>

--- a/packages/effekt/src/sequence/types/sequence.ts
+++ b/packages/effekt/src/sequence/types/sequence.ts
@@ -1,0 +1,13 @@
+import type { SequencePromise } from './options'
+
+export interface Sequence {
+  play(): Promise<void>
+  pause(): void
+  stop(): void
+  complete(): void
+  cancel(): void
+  completed: SequencePromise
+  get timeline(): globalThis.AnimationTimeline | null
+  set timeline(t: globalThis.AnimationTimeline | null)
+  get isCompleted(): Readonly<boolean>
+}

--- a/packages/effekt/src/types/sequence.ts
+++ b/packages/effekt/src/types/sequence.ts
@@ -1,0 +1,5 @@
+// Exports types intended only for the `sequence` package
+// import type { ... } from 'effekt/sequence'
+
+export * from '@/sequence/types'
+export * from '@/sequence'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@hypernym/eslint-config':
-        specifier: ^3.5.5
-        version: 3.5.5(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
+        specifier: ^3.5.6
+        version: 3.5.6(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       '@hypernym/prettier-config':
         specifier: ^3.2.2
         version: 3.2.2(prettier@3.4.2)
@@ -298,8 +298,8 @@ packages:
       typescript:
         optional: true
 
-  '@hypernym/eslint-config@3.5.5':
-    resolution: {integrity: sha512-74PowI+SfoAPg9bSfeZ6dzkmW56VIw6xB6udYE0KXmq7Z3g0iu2lLEIQo8RE1hxD2mmkKRcw6Pf3rjpfUO+CUw==}
+  '@hypernym/eslint-config@3.5.6':
+    resolution: {integrity: sha512-Ux/P4mshfMlC0FrqcwRGx85FAkTKHO08ETPBHhyZ0B6/f6ZU/qvsp9MWlTpB2dSom3URF5JLW5LTGmlJlNpDRQ==}
     engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
     peerDependencies:
       eslint: '>=9.0.0'
@@ -1390,7 +1390,7 @@ snapshots:
       '@types/node': 22.13.1
       typescript: 5.7.3
 
-  '@hypernym/eslint-config@3.5.5(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@hypernym/eslint-config@3.5.6(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint/js': 9.19.0
       '@types/eslint': 9.6.1


### PR DESCRIPTION

## Type of Change

- [x] New feature

## Request Description

Adds a new `sequence` function.

This will be available as a separate subpath of `Effekt's` modular system.

This way you have the choice to import only what you really need. 

Also, its a very lightweight (size: `~2 KB` or `~980 B` minified) solution as well as others modules.

### sequence

Creates a new `Sequence` object that plays animations in a specified order.

The `sequence` function allows you to chain multiple animations with precise control and synchronization of each step in the sequence.

Ensures that animations are played sequentially, with the ability to define other properties and methods to manage the flow of the animations.

```ts
import { sequence } from 'effekt/sequence'

const sq = sequence([
  ['.el1', { opacity: [1, 0.5] }],
  ['.el2', { opacity: [0.5, 1] }],
  // ...
])

sq.play() // Plays the sequence
```