### PR TITLE
feat: add new inView function

### DIFF
--- a/packages/effekt/src/interaction/in-view.ts
+++ b/packages/effekt/src/interaction/in-view.ts
@@ -1,0 +1,92 @@
+import { getElements } from '@/utils'
+import { noop, isFunction } from '@/shared'
+import type { AnimationTargets } from '@/animation/types'
+import type { InViewOptions, InViewCallback } from './types'
+
+/**
+ * Triggers a callback when the specified elements enter and leave the viewport.
+ *
+ * Useful for optimizing performance by only running actions when elements are visible in the viewport.
+ *
+ * Reduces unnecessary operations on off-screen elements, making it especially beneficial in dynamic or single-page apps where elements may frequently appear and disappear.
+ *
+ * Use Cases:
+ *
+ * - Animations: Triggers animations (fade-in/out, slide-up, etc.) when elements enter or leave the viewport.
+ * - Lazy Loading: Loads images, videos, or other resources when they come into view, improving initial page load performance.
+ * - Infinite Scroll: Detects when the user scrolls to the bottom of the page or container, then loads additional content.
+ *
+ * @example
+ *
+ * ```ts
+ * import { animate } from 'effekt'
+ * import { inView } from 'effekt/interaction'
+ *
+ * inView('.el', ({ target }) => {
+ *   // Triggered when the target enters the viewport
+ *   animate(target, { opacity: [0, 1] })
+ *
+ *   // Triggered when the target leaves the viewport
+ *   return (info) => {
+ *     animate(target, { opacity: [1, 0] })
+ *     console.log(info)
+ *   }
+ * })
+ * ```
+ *
+ * The function returns a cleanup function that can be invoked to stop observing the elements when needed,
+ * such as when the component is destroyed or when the observer is no longer required.
+ *
+ * @example
+ *
+ * ```ts
+ * const stopInView = inView('.el', ({ target }) => {
+ *   animate(target, { opacity: [0, 1] })
+ * })
+ *
+ * // Stops viewport detection
+ * stopInView()
+ * ```
+ */
+export function inView(
+  targets: AnimationTargets,
+  onEnter: (entry: IntersectionObserverEntry) => void | InViewCallback,
+  options: InViewOptions = {},
+): VoidFunction {
+  const { root, margin, threshold } = options
+
+  const els = getElements(targets)
+  if (!els.length) return noop
+
+  const intersections: WeakMap<Element, InViewCallback> = new WeakMap()
+
+  const onIntersectionChange: IntersectionObserverCallback = (entries) => {
+    entries.forEach((entry) => {
+      const { target, isIntersecting } = entry
+
+      const onLeave = intersections.get(target)
+
+      if (isIntersecting === !!onLeave) return
+
+      if (isIntersecting) {
+        const newOnLeave = onEnter(entry)
+
+        if (isFunction(newOnLeave)) intersections.set(target, newOnLeave)
+        else observer.unobserve(target)
+      } else if (isFunction(onLeave)) {
+        onLeave(entry)
+        intersections.delete(target)
+      }
+    })
+  }
+
+  const observer = new IntersectionObserver(onIntersectionChange, {
+    root,
+    rootMargin: margin,
+    threshold,
+  })
+
+  els.forEach((el) => observer.observe(el))
+
+  return () => observer.disconnect()
+}

--- a/packages/effekt/src/interaction/index.ts
+++ b/packages/effekt/src/interaction/index.ts
@@ -1,0 +1,1 @@
+export * from './in-view'

--- a/packages/effekt/src/interaction/types/in-view.ts
+++ b/packages/effekt/src/interaction/types/in-view.ts
@@ -1,0 +1,41 @@
+export type InViewCallback = (entry: IntersectionObserverEntry) => void
+
+type RootMarginString = `${number}${'px' | '%'}`
+export type RootMargin =
+  | RootMarginString
+  | `${RootMarginString} ${RootMarginString}`
+  | `${RootMarginString} ${RootMarginString} ${RootMarginString}`
+  | `${RootMarginString} ${RootMarginString} ${RootMarginString} ${RootMarginString}`
+
+export interface InViewOptions {
+  /**
+   * Specifies the element to be used as the viewport for detecting the visibility of the target element.
+   *
+   * The root element must be an ancestor of the target. If not provided or set to null, the browser's viewport will be used.
+   *
+   * @default undefined
+   */
+  root?: Document | Element | null
+  /**
+   * Specifies the margin around the `root` element. This value is a string with up to four values, similar to CSS margin property.
+   *
+   * The values can be in absolute lengths (`px`) or percentages (`%`), and they define the expansion or shrinkage of the root's bounding box.
+   *
+   * Negative values will shrink the root's bounding box, while positive values will expand it.
+   *
+   * @default '0px 0px 0px 0px'
+   */
+  margin?: RootMargin
+  /**
+   * Specifies a single number or an array of numbers indicating the percentage of the target's visibility required to trigger the observer's callback.
+   *
+   * - `0` means the callback is triggered as soon as any part of the target is visible.
+   * - `0.5` means the callback will trigger when 50% of the target is visible.
+   * - `1` means the callback will only be triggered when the entire target is fully visible.
+   *
+   * If an array is provided, the callback will be triggered whenever the target's visibility crosses any of the specified thresholds.
+   *
+   * @default 0
+   */
+  threshold?: number | number[]
+}

--- a/packages/effekt/src/interaction/types/index.ts
+++ b/packages/effekt/src/interaction/types/index.ts
@@ -1,0 +1,1 @@
+export * from './in-view'

--- a/packages/effekt/src/types/interaction.ts
+++ b/packages/effekt/src/types/interaction.ts
@@ -1,0 +1,5 @@
+// Exports types intended only for the `interaction` package
+// import type { ... } from 'effekt/interaction'
+
+export * from '@/interaction/types'
+export * from '@/interaction'


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Request Description

Adds a new `inView` function.

This will be available as a separate subpath of `Effekt's` modular system.

This way you have the choice to import only what you really need.

Also, its a very lightweight (size: `~1 KB` or `~510 B` minified) solution as well as others modules.

### inView

Triggers a callback when the specified elements enter and leave the viewport.

Useful for optimizing performance by only running actions when elements are visible in the viewport.

Reduces unnecessary operations on off-screen elements, making it especially beneficial in dynamic or single-page apps where elements may frequently appear and disappear.

#### Use Cases:

- Animations: Triggers animations (fade-in/out, slide-up, etc.) when elements enter or leave the viewport.
- Lazy Loading: Loads images, videos, or other resources when they come into view, improving initial page load performance.
- Infinite Scroll: Detects when the user scrolls to the bottom of the page or container, then loads additional content.

```ts
import { animate } from 'effekt'
import { inView } from 'effekt/interaction'

inView('.el', ({ target }) => {
  // Triggered when the target enters the viewport
  animate(target, { opacity: [0, 1] })

  // Triggered when the target leaves the viewport
  return (info) => {
    animate(target, { opacity: [1, 0] })
    console.log(info)
  }
})
```

The function returns a cleanup function that can be invoked to stop observing the elements when needed, such as when the component is destroyed or when the observer is no longer required.

```ts
const stopInView = inView('.el', ({ target }) => {
  animate(target, { opacity: [0, 1] })
})

// Stops viewport detection
stopInView()
```